### PR TITLE
fix for multiplayer death crash

### DIFF
--- a/homeworld_logic.lua
+++ b/homeworld_logic.lua
@@ -318,7 +318,7 @@ function Homeworld:tick( tick )
    for player_index = 1, #game.players do
       local player = game.players[player_index]
       local held_item = player.cursor_stack
-      local holding_pda = (held_item.valid_for_read and held_item.name == pda_name)
+      local holding_pda = (held_item and held_item.valid_for_read and held_item.name == pda_name)
       if self.state.using_pda[player_index] and not holding_pda then
          self.state.using_pda[player_index] = nil
          self:hide_gui(player_index)


### PR DESCRIPTION
help_item can be nil and may not be indexed then
see issue #9 
