### PR TITLE
minor changes

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -24,9 +24,24 @@ register_entity_actor(Portal, "homeworld_portal")
 register_entity_actor(BeltThroughputReader, "belt_throughput_reader")
 register_entity_actor(BeltGate, "belt_gate")
 
+function insert_starting_items()
+  for player_index = 1, #game.players do
+    local player = game.players[player_index]
+    player.insert{
+      name = "homeworld_portal",
+      count = 1
+    }
+    player.insert{
+      name = "portable-electronics",
+      count = 1
+    }
+  end
+end
+
 function on_mod_init( event )
     GUI.init()
     Homeworld:init()
+    insert_starting_items()
 end
 
 function on_mod_load( event )
@@ -48,18 +63,6 @@ function on_tick( event )
     if ModuloTimer(20) then
     	Fishery.update_fish_chunks()
     end
-end
-
-function on_player_created( event )
-    local player = game.players[event.player_index]
-    player.insert{
-        name = "homeworld_portal",
-        count = 1
-   }
-   player.insert{
-       name = "portable-electronics",
-       count = 1
-   }
 end
 
 function on_resource_depleted( event )
@@ -115,7 +118,6 @@ script.on_load(on_mod_load)
 script.on_event(defines.events.on_built_entity, on_built_entity)
 script.on_event(defines.events.on_robot_built_entity, on_built_entity)
 script.on_event(defines.events.on_entity_died, on_entity_died)
-script.on_event(defines.events.on_player_created, on_player_created)
 script.on_event(defines.events.on_preplayer_mined_item, before_player_mined_item)
 script.on_event(defines.events.on_robot_pre_mined, before_robot_mined)
 script.on_event(defines.events.on_resource_depleted, on_resource_depleted)

--- a/homeworld_logic.lua
+++ b/homeworld_logic.lua
@@ -318,7 +318,7 @@ function Homeworld:tick( tick )
    for player_index = 1, #game.players do
       local player = game.players[player_index]
       local held_item = player.cursor_stack
-      local holding_pda = (held_item.valid_for_read and held_item.name == pda_name)
+      local holding_pda = (held_item and held_item.valid_for_read and held_item.name == pda_name)
       if self.state.using_pda[player_index] and not holding_pda then
          self.state.using_pda[player_index] = nil
          self:hide_gui(player_index)

--- a/info.json
+++ b/info.json
@@ -1,7 +1,7 @@
 {
   "name": "homeworld",
   "version": "1.4.1",
-  "factorio_version": "0.13",
+  "factorio_version": "0.14",
   "title": "Homeworld",
   "author": "Luke Perkin",
   "contact": "",

--- a/prototypes/entities.lua
+++ b/prototypes/entities.lua
@@ -65,6 +65,7 @@ data:extend({
         name = "homeworld_portal",
         icon = "__homeworld__/graphics/icons/portal.png",
         flags = {"player-creation", "placeable-player"},
+        minable = {mining_time = 0.3, result = "homeworld_portal"},
         render_layer = "floor",
         max_health = 150,
         corpse = "big-remnants",

--- a/tiers.lua
+++ b/tiers.lua
@@ -6,7 +6,7 @@
 
 local rewards01 = {
     {
-        {name = "firearm-bullet-magazine", count = 300},
+        {name = "firearm-magazine", count = 300},
         {name = "light-armor", count = 3}
     },
     {


### PR DESCRIPTION
"existing save" commit:
on_init(f) " is called once when a new save game is created or once when a save file is loaded that previously didn't contain the mod."
http://lua-api.factorio.com/latest/LuaBootstrap.html#LuaBootstrap.on_init
So it should be fine to init that way.

mining:
Was there a reason to disallow mining portal? It's more convenient to move it as needed.